### PR TITLE
Wrong fee on bittrex

### DIFF
--- a/exchanges/bittrex.js
+++ b/exchanges/bittrex.js
@@ -164,7 +164,7 @@ Trader.prototype.getFee = function(callback) {
 
   this.bittrexApi.getcurrencies(set); */
 
-   callback(false, parseFloat(0.00025));
+   callback(false, parseFloat(0.0025));
 }
 
 Trader.prototype.buy = function(amount, price, callback) {


### PR DESCRIPTION
Fee on bittrex is 0.25%

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
